### PR TITLE
Make keys with an extension clickable as files.

### DIFF
--- a/Sources/FileModule/Bundle/Templates/Admin/Browser.html
+++ b/Sources/FileModule/Bundle/Templates/Admin/Browser.html
@@ -54,7 +54,13 @@ tr {
         #for(item in children):
     <tr>
         <td class="td:left m:h:s"><a href="#($req.url.path)?key=#(item.key)">#if(item.ext == nil):#svg("folder")#elseif(["png", "jpg", "jpeg"].contains(item.ext)):<img src="#(item.key.resolve())">#else:#svg("file")#endif</a></td>
-        <td class="td:left m:h:s td:separator"><a href="#($req.url.path)?key=#(item.key)">#(item.name)</a></td>
+        <td class="td:left m:h:s td:separator">
+            #if(item.ext != nil):
+            <a href="#(item.key.resolve())" target="_blank">#(item.name)</a>
+            #else:
+            <a href="#($req.url.path)?key=#(item.key)">#(item.name)</a>
+            #endif
+        </td>
         <td class="td:center">#if(item.ext != nil):<a href="#(item.key.resolve())" target="_blank">#svg("eye")</a>#else:&nbsp;#endif</td>
         #if(UserHasPermission("file.browser.delete")):
         <td class="td:center"><a href="#($req.url.path.trimLast())delete/?key=#(item.key)&cancel=#($req.url.path)?key=#Request(query: "key")">#svg("trash")</a></td>


### PR DESCRIPTION
LiquidKit doesn't currently have a way to deterine if a key is a directory or a file, this mostly works in the interim.
Fixes featherCMS/feather#52.